### PR TITLE
take only the first field of the upstream modulation string

### DIFF
--- a/ubee-prometheus.go
+++ b/ubee-prometheus.go
@@ -136,7 +136,7 @@ func getPrometheus() string {
 				ret += doUSField(us.Us_type, "type", id,  "Type of this channel", "gauge")
 				ret += doUSField(us.Us_freq, "freq", id,  "Frequency of this channel", "gauge")
 				ret += doUSField(us.Us_width, "width", id,  "Width of this channel", "gauge")
-				ret += doUSField(us.Us_modulation, "modulation", id,  "Modulation of this channel", "gauge")
+				ret += doUSField(strings.Fields(us.Us_modulation)[0], "modulation", id,  "Modulation of this channel", "gauge")
 			}
 		}
 	}


### PR DESCRIPTION
On my modem (UBC1318ZG) the upstream modulation is reported as
"3 4 12 13". This causes strconv.ParseFloat to barf. Work around
this by only taking the first field of the string. This loses
information, but I wouldn't know how to properly solve this and
it doesn't seem to be a very important metric to track.